### PR TITLE
Time#parse isn't available unless explicitly required.

### DIFF
--- a/lib/packet/entity/timestamps.rb
+++ b/lib/packet/entity/timestamps.rb
@@ -1,3 +1,4 @@
+require 'time'
 require 'active_support/concern'
 
 module Packet


### PR DESCRIPTION
```
/Users/Michael/.gem/ruby/2.3.0/gems/packethost-0.0.4/lib/packet/entity/timestamps.rb:12:in `block (2 levels) in has_timestamps': undefined method `parse' for Time:Class (NoMethodError)
	from /Users/Michael/.gem/ruby/2.3.0/gems/packethost-0.0.4/lib/packet/entity/base.rb:52:in `instance_exec'
	from /Users/Michael/.gem/ruby/2.3.0/gems/packethost-0.0.4/lib/packet/entity/base.rb:52:in `_cast_value'
	from /Users/Michael/.gem/ruby/2.3.0/gems/packethost-0.0.4/lib/packet/entity/base.rb:28:in `block in update_attributes'
	from /Users/Michael/.gem/ruby/2.3.0/gems/packethost-0.0.4/lib/packet/entity/base.rb:26:in `each_pair'
	from /Users/Michael/.gem/ruby/2.3.0/gems/packethost-0.0.4/lib/packet/entity/base.rb:26:in `update_attributes'
	from /Users/Michael/.gem/ruby/2.3.0/gems/packethost-0.0.4/lib/packet/entity/base.rb:22:in `initialize'
	from /Users/Michael/.gem/ruby/2.3.0/gems/packethost-0.0.4/lib/packet/client/projects.rb:5:in `new'
	from /Users/Michael/.gem/ruby/2.3.0/gems/packethost-0.0.4/lib/packet/client/projects.rb:5:in `block in list_projects'
	from /Users/Michael/.gem/ruby/2.3.0/gems/packethost-0.0.4/lib/packet/client/projects.rb:5:in `map'
	from /Users/Michael/.gem/ruby/2.3.0/gems/packethost-0.0.4/lib/packet/client/projects.rb:5:in `list_projects'
	from /Users/Michael/.gem/ruby/2.3.0/gems/packethost-0.0.4/lib/packet.rb:46:in `method_missing'
	from ./api.rb:13:in `<main>'
```