### PR TITLE
Fix serialization of devices to solve problems with create_device.

### DIFF
--- a/lib/packet/device.rb
+++ b/lib/packet/device.rb
@@ -4,7 +4,7 @@ module Packet
   class Device
     include Entity
 
-    attr_accessor :hostname, :iqn, :ip_addresses, :state, :tags, :userdata
+    attr_accessor :hostname, :iqn, :ip_addresses, :state, :tags, :userdata, :project_id
     has_one :operating_system
     has_one :plan
     has_one :facility

--- a/lib/packet/entity/serialization.rb
+++ b/lib/packet/entity/serialization.rb
@@ -5,11 +5,21 @@ module Packet
     module Serialization
       extend ActiveSupport::Concern
 
+      class_methods do
+        def serializer_key(value)
+          define_method :to_value do
+            instance_variable_get "@#{value}"
+          end
+        end
+      end
+
       def to_hash
         instance_variables.reject { |ivar| [:@client].include?(ivar) }.map do |ivar|
-          [ivar.to_s.tr('@', ''), instance_variable_get(ivar)]
+          ival = instance_variable_get(ivar)
+          [ivar.to_s.tr('@', ''), ival.respond_to?(:to_value) ? ival.to_value : instance_variable_get(ivar)]
         end.to_h
       end
+
       alias to_h to_hash
     end
   end

--- a/lib/packet/facility.rb
+++ b/lib/packet/facility.rb
@@ -5,5 +5,7 @@ module Packet
     attr_accessor :name
     attr_accessor :code
     attr_accessor :features
+
+    serializer_key :code
   end
 end

--- a/lib/packet/operating_system.rb
+++ b/lib/packet/operating_system.rb
@@ -7,5 +7,7 @@ module Packet
     attr_accessor :distro
     attr_accessor :version
     attr_accessor :provisionable_on
+
+    serializer_key :slug
   end
 end

--- a/lib/packet/plan.rb
+++ b/lib/packet/plan.rb
@@ -8,5 +8,7 @@ module Packet
     attr_accessor :line
     attr_accessor :specs
     attr_accessor :pricing
+
+    serializer_key :slug
   end
 end

--- a/lib/packet/project.rb
+++ b/lib/packet/project.rb
@@ -7,5 +7,9 @@ module Packet
     has_many :devices
     has_many :ssh_keys
     has_timestamps
+
+    def new_device(opts={})
+      Packet::Device.new(opts.merge(project_id: id))
+    end
   end
 end

--- a/lib/packet/project.rb
+++ b/lib/packet/project.rb
@@ -8,7 +8,7 @@ module Packet
     has_many :ssh_keys
     has_timestamps
 
-    def new_device(opts={})
+    def new_device(opts = {})
       Packet::Device.new(opts.merge(project_id: id))
     end
   end

--- a/lib/packet/ssh_key.rb
+++ b/lib/packet/ssh_key.rb
@@ -5,6 +5,8 @@ module Packet
     attr_accessor :label
     attr_accessor :key
 
+    serializer_key :id
+
     has_timestamps
   end
 end

--- a/spec/lib/packet/device_spec.rb
+++ b/spec/lib/packet/device_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+RSpec.describe Packet::Device do
+  let(:plan) { Packet::Plan.new(slug: 'test_slug') }
+
+  before do
+    allow(plan).to receive(:to_value)
+  end
+
+  subject { Packet::Device.new(plan: plan.to_hash) }
+
+  describe '#to_hash output should have values instead of objects for children' do
+    it { expect(subject.to_hash['plan']).to be_a(String) }
+    it { expect(subject.to_hash['plan']).to eq plan.slug }
+  end
+
+end

--- a/spec/lib/packet/device_spec.rb
+++ b/spec/lib/packet/device_spec.rb
@@ -13,5 +13,4 @@ RSpec.describe Packet::Device do
     it { expect(subject.to_hash['plan']).to be_a(String) }
     it { expect(subject.to_hash['plan']).to eq plan.slug }
   end
-
 end

--- a/spec/lib/packet/project_spec.rb
+++ b/spec/lib/packet/project_spec.rb
@@ -90,5 +90,14 @@ RSpec.describe Packet::Project do
     end
   end
 
+  describe '#new_device' do
+    before { subject.id = SecureRandom.uuid }
+
+    it 'creates a Packet::Device object that has a project_id instance variable' do
+      expect(subject.new_device.project_id).to eq subject.id
+    end
+
+  end
+
   it_behaves_like 'an entity'
 end

--- a/spec/lib/packet/project_spec.rb
+++ b/spec/lib/packet/project_spec.rb
@@ -96,7 +96,6 @@ RSpec.describe Packet::Project do
     it 'creates a Packet::Device object that has a project_id instance variable' do
       expect(subject.new_device.project_id).to eq subject.id
     end
-
   end
 
   it_behaves_like 'an entity'


### PR DESCRIPTION
1) The `create_device` method calls `device.to_hash` and tries to use that as the parameters for the API `create_device` request. This does not work, as the API expects to get direct values, such as `"plan" : "baremetal_0"`. The device.to_hash would serialize to something like `"plan" : "#<Packet::Plan:xxx ....>"`.

To fix this, I added a `serializer_key` method to the entity serializer, with it you can do something like `serializer_key :slug` in the entity definition to select which instance variable will be used as the value when serializing for a parent object.

2) The `create_device` method needs `device.project_id` to build the POST url, device did not have project_id so i added it as a regular attr_accessor instance variable and also created `project.new_device(opts)` method that will build a project entity instance just like `Packet::Device.new' but inserts the project id into it.
