### PR TITLE
Device power state actions

### DIFF
--- a/lib/packet/client/devices.rb
+++ b/lib/packet/client/devices.rb
@@ -25,6 +25,10 @@ module Packet
         action(device, 'reboot')
       end
 
+      def rescue_device(device)
+        action(device, 'rescue')
+      end
+
       def power_on_device(device)
         action(device, 'power_on')
       end

--- a/lib/packet/client/devices.rb
+++ b/lib/packet/client/devices.rb
@@ -21,6 +21,22 @@ module Packet
         end
       end
 
+      def reboot_device(device)
+        action(device, 'reboot')
+      end
+
+      def rebuild_device(device)
+        action(device, 'rebuild')
+      end
+
+      def power_on_device(device)
+        action(device, 'power_on')
+      end
+
+      def power_off_device(device)
+        action(device, 'power_off')
+      end
+
       def delete_device(device_or_id)
         id = if device_or_id.is_a?(Packet::Device)
                device_or_id.id
@@ -28,6 +44,14 @@ module Packet
                device_or_id
              end
         delete("devices/#{id}")
+      end
+
+      private
+
+      def action(device, action_type)
+        post("devices/#{device.id}/actions", type: action_type).tap do |response|
+          device.update_attributes(response.body)
+        end
       end
     end
   end

--- a/lib/packet/client/devices.rb
+++ b/lib/packet/client/devices.rb
@@ -49,9 +49,7 @@ module Packet
       private
 
       def action(device, action_type)
-        post("devices/#{device.id}/actions", type: action_type).tap do |response|
-          device.update_attributes(response.body)
-        end
+        post("devices/#{device.id}/actions", type: action_type).success?
       end
     end
   end

--- a/lib/packet/client/devices.rb
+++ b/lib/packet/client/devices.rb
@@ -25,10 +25,6 @@ module Packet
         action(device, 'reboot')
       end
 
-      def rebuild_device(device)
-        action(device, 'rebuild')
-      end
-
       def power_on_device(device)
         action(device, 'power_on')
       end

--- a/spec/lib/packet/client_spec.rb
+++ b/spec/lib/packet/client_spec.rb
@@ -146,7 +146,6 @@ RSpec.describe Packet::Client do
     describe '#delete_device'
     describe '#update_device'
     describe '#reboot_device'
-    describe '#rebuild_device'
     describe '#power_on_device'
     describe '#power_off_device'
   end

--- a/spec/lib/packet/client_spec.rb
+++ b/spec/lib/packet/client_spec.rb
@@ -146,6 +146,7 @@ RSpec.describe Packet::Client do
     describe '#delete_device'
     describe '#update_device'
     describe '#reboot_device'
+    describe '#rescue_device'
     describe '#power_on_device'
     describe '#power_off_device'
   end

--- a/spec/lib/packet/client_spec.rb
+++ b/spec/lib/packet/client_spec.rb
@@ -145,5 +145,9 @@ RSpec.describe Packet::Client do
     describe '#create_device'
     describe '#delete_device'
     describe '#update_device'
+    describe '#reboot_device'
+    describe '#rebuild_device'
+    describe '#power_on_device'
+    describe '#power_off_device'
   end
 end


### PR DESCRIPTION
Added:

- `client.power_on_device(device)`
- `client.power_off_device(device)`
- `client.reboot_device(device)`
- `client.rebuild_device(device)`

The tests for device actions would just be testing the mock framework.

```ruby
> client = Packet::Client.new(API_KEY)
> client.power_off_device(client.get_device(DEVICE_ID))
 => true
> client.power_off_device(client.get_device(DEVICE_ID))
Packet::Error: {"errors"=>["Device must be powered on"]}
```
