### PR TITLE
Add support for project ssh keys.

### DIFF
--- a/lib/packet/client/ssh_keys.rb
+++ b/lib/packet/client/ssh_keys.rb
@@ -5,12 +5,24 @@ module Packet
         get('ssh-keys', *args).body['ssh_keys'].map { |p| Packet::SshKey.new(p, self) }
       end
 
+      def list_project_ssh_keys(project_or_id, *args)
+        id = project_id(project_or_id)
+        get("project/#{id}/ssh-keys", *args).body['ssh_keys'].map { |p| Packet::SshKey.new(p, self) }
+      end
+
       def get_ssh_key(id, *args)
         Packet::SshKey.new(get("ssh-keys/#{id}", *args).body, self)
       end
 
       def create_ssh_key(ssh_key)
         post('ssh-keys', ssh_key.to_hash).tap do |response|
+          ssh_key.update_attributes(response.body)
+        end
+      end
+
+      def create_project_ssh_key(ssh_key, project_or_id)
+        id = project_id(project_or_id)
+        post("project/#{id}/ssh-keys", ssh_key.to_hash).tap do |response|
           ssh_key.update_attributes(response.body)
         end
       end
@@ -28,6 +40,16 @@ module Packet
                ssh_key_or_id
              end
         delete("ssh-keys/#{id}")
+      end
+
+      private
+
+      def project_id(project_or_id)
+        if project_or_id.is_a?(Packet::Project)
+          project_or_id.id
+        else
+          project_or_id
+        end
       end
     end
   end


### PR DESCRIPTION
This commit adds support for creating project specific keys and
retrieving project specific ssh keys.

The missing http requests are described in the [docs](https://www.packet.net/developers/api/sshkeys/)
The added ones are:
  - `GET /projects/{id}/ssh-keys`
  - `POST /projects/{id}/ssh-keys`

I tried following the style so far, I didn't find a test file, so let me
know if you want me to write some tests(although there were fixtures, so maybe I am just blind). I believe the code is self explanatory.