### PR TITLE
Bump activesupport version to rails 5.1

### DIFF
--- a/packethost.gemspec
+++ b/packethost.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
 
-  spec.add_dependency 'activesupport', '~> 4.2'
+  spec.add_dependency 'activesupport', '~> 5.1'
   spec.add_dependency 'faraday', '>= 0.9.0'
   spec.add_dependency 'faraday_middleware', '>= 0.9.0'
 


### PR DESCRIPTION
This change will help people deploy the packet API to rails 5.1
applications, since rails requires the newest activesupport.