### PR TITLE
Update Ruby versions and cache Bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
+cache: bundler
 rvm:
-  - 2.3.0
-  - 2.2.4
-  - 2.1.8
-  - 2.0.0-p648
+  - 2.5.1
+  - 2.4.4
+  - 2.3.7
+  - 2.2.10
 env:
   - "COVERAGE=true"


### PR DESCRIPTION
2.0 and 2.1 are EOL.
There are newer Ruby versions we should support.
Also, caching would speed up the build.